### PR TITLE
Use aioConfig instead of process.env

### DIFF
--- a/src/lib/app-helper.js
+++ b/src/lib/app-helper.js
@@ -18,7 +18,7 @@ const { getToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
 const fetch = require('node-fetch')
 const chalk = require('chalk')
-const config = require('@adobe/aio-lib-core-config')
+const aioConfig = require('@adobe/aio-lib-core-config')
 const { AIO_CONFIG_WORKSPACE_SERVICES, AIO_CONFIG_ORG_SERVICES } = require('./defaults')
 const { EOL } = require('os')
 
@@ -288,9 +288,10 @@ function waitFor (t) {
 /** @private */
 async function runOpenWhiskJar (jarFile, runtimeConfigFile, apihost, waitInitTime, waitPeriodTime, timeout, /* istanbul ignore next */ execaOptions = {}) {
   aioLogger.debug(`runOpenWhiskJar - jarFile: ${jarFile} runtimeConfigFile ${runtimeConfigFile} apihost: ${apihost} waitInitTime: ${waitInitTime} waitPeriodTime: ${waitPeriodTime} timeout: ${timeout}`)
-  const jvmArgs = process.env.AIO_OW_JVM_ARGS ? process.env.AIO_OW_JVM_ARGS.split(' ') : [];
+  const jvmConfig = aioConfig.get('ow.jvm.args')
+  const jvmArgs = jvmConfig ? jvmConfig.split(' ') : []
   const proc = execa('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', ...jvmArgs, jarFile, '-m', runtimeConfigFile, '--no-ui', '--disable-color-logging'], execaOptions)
-  
+
   const endTime = Date.now() + timeout
   await waitFor(waitInitTime)
   await waitForOpenWhiskReadiness(apihost, endTime, waitPeriodTime, timeout, waitFor)
@@ -335,7 +336,7 @@ function setWorkspaceServicesConfig (serviceProperties) {
     name: s.name,
     code: s.sdkCode
   }))
-  config.set(AIO_CONFIG_WORKSPACE_SERVICES, serviceConfig, true)
+  aioConfig.set(AIO_CONFIG_WORKSPACE_SERVICES, serviceConfig, true)
   aioLogger.debug(`set aio config ${AIO_CONFIG_WORKSPACE_SERVICES}: ${JSON.stringify(serviceConfig, null, 2)}`)
 }
 
@@ -350,7 +351,7 @@ function setOrgServicesConfig (supportedServices) {
     code: s.code,
     type: s.type
   }))
-  config.set(AIO_CONFIG_ORG_SERVICES, orgServiceConfig, true)
+  aioConfig.set(AIO_CONFIG_ORG_SERVICES, orgServiceConfig, true)
   aioLogger.debug(`set aio config ${AIO_CONFIG_ORG_SERVICES}: ${JSON.stringify(orgServiceConfig, null, 2)}`)
 }
 

--- a/test/commands/lib/app-helper.test.js
+++ b/test/commands/lib/app-helper.test.js
@@ -26,7 +26,6 @@ beforeEach(() => {
   fetch.mockReset()
   config.get.mockReset()
   config.set.mockReset()
-  delete process.env.AIO_OW_JVM_ARGS
 })
 
 test('isDockerRunning', async () => {
@@ -527,14 +526,14 @@ test('runOpenWhiskJar ok', async () => {
     proc: expect.any(Object)
   })
   expect(fetch).toHaveBeenCalledTimes(1)
-  expect(execa).toHaveBeenCalledWith('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', 'jar', '-m', 'conf', '--no-ui', '--disable-color-logging'], {});
+  expect(execa).toHaveBeenCalledWith('java', expect.arrayContaining(['jar', 'conf']), {})
 })
 
 test('runOpenWhiskJar with AIO_OW_JVM_ARGS env var is passed to execa', async () => {
   fetch.mockReturnValue({ ok: true })
   execa.mockReturnValue({ stdout: jest.fn() })
 
-  process.env.AIO_OW_JVM_ARGS = 'arg1 arg2'
+  config.get.mockReturnValueOnce('arg1 arg2')
 
   const result = appHelper.runOpenWhiskJar('jar', 'conf')
 
@@ -542,7 +541,7 @@ test('runOpenWhiskJar with AIO_OW_JVM_ARGS env var is passed to execa', async ()
     proc: expect.any(Object)
   })
   expect(fetch).toHaveBeenCalledTimes(1)
-  expect(execa).toHaveBeenCalledWith('java', ['-jar', '-Dwhisk.concurrency-limit.max=10', 'arg1', 'arg2', 'jar', '-m', 'conf', '--no-ui', '--disable-color-logging'], {});
+  expect(execa).toHaveBeenCalledWith('java', expect.arrayContaining(['arg1', 'arg2', 'jar', 'conf']), {})
 })
 
 test('waitForOpenWhiskReadiness timeout', async () => {


### PR DESCRIPTION
This pr essentially just changes the use of process.env to be aioConfig.get()

All `AIO_` prefixed process.env values will be accessible via `aioConfig.get( )` minus their 'aio' prefix.
So `process.env.AIO_SOME_VALUE` is also available as `aioConfig.get('some.value')`

This allows values to be specified:
1. on the command line, via `AIO_SOME_VALUE='boo' aio app run --local`
2. adding the same values  to .env file
3. adding `some: { value: 'boo' }` to the .aio file
4. setting global config and have it used for all `app run --local`
- `aio config set ow.jvm.args 'some values'`
